### PR TITLE
change missing mappings.json from fatal to warn

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -19,7 +19,7 @@ function IBMCloudEnv(){
 		mappingsFilePath = process.cwd() + mappingsFilePath;
 		logger.info("Initializing with", mappingsFilePath);
 		if (!fs.existsSync(mappingsFilePath)){
-			logger.fatal("File does not exist", mappingsFilePath);
+			logger.warn("File does not exist", mappingsFilePath);
 			return;
 		}
 


### PR DESCRIPTION
Change error level from fatal to warn for missing mappings.json file, since it is valid for a project to have zero cloud service mappings. 