### PR TITLE
add unit test for search

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -104,7 +104,7 @@ function IBMCloudEnv() {
 				return processJSONPath(vcapApplicationString, patternComponents[1]);
 			}
 		} else {
-			// patternComponents[1] is a service instance name, find it in VCAP_SERVIES and return credentials object
+			// patternComponents[1] is a service instance name, find it in VCAP_SERVICES and return credentials object
 			let jsonPath = '$..[?(@.name=="' + patternComponents[1] + '")].credentials';
 			return processJSONPath(vcapServicesString, jsonPath);
 		}

--- a/server/config/mappings.json
+++ b/server/config/mappings.json
@@ -26,7 +26,7 @@
 	},
 	"cf_var4":{
 		"searchPatterns": [
-			"cloudfoundry:$.[?(@.name == 'service1-name1')].credentials.username"
+			"cloudfoundry:$.*[?(@.name == 'service1-name1')].credentials.username"
 		]
 	},
 	"env_var1":{

--- a/server/config/mappings.json
+++ b/server/config/mappings.json
@@ -24,6 +24,11 @@
 			"cloudfoundry:$.application_name"
 		]
 	},
+	"cf_var4":{
+		"searchPatterns": [
+			"cloudfoundry:$.[?(@.name == 'service1-name1')].credentials.username"
+		]
+	},
 	"env_var1":{
 		"searchPatterns": [
 			"env:ENV_VAR_STRING"

--- a/test/fake-env-vars.js
+++ b/test/fake-env-vars.js
@@ -3,13 +3,13 @@ process.env.VCAP_SERVICES = JSON.stringify({
 		{
 			name: "service1-name1",
 			credentials: {
-				username: "service1-username1",
+				username: "service1-username1"
 			}
 		},
 		{
 			name: "service1-name2",
 			credentials: {
-				username: "service1-username2",
+				username: "service1-username2"
 			}
 		}
 	],

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,11 @@ describe('App', function () {
 		expect(IBMCloudEnv.getDictionary("cf_var3")).to.be.an("object");
 		expect(IBMCloudEnv.getDictionary("cf_var3")).to.have.a.property("value");
 		expect(IBMCloudEnv.getDictionary("cf_var3").value).to.equal("test-application");
+		
+		expect(IBMCloudEnv.getString("cf_var4")).to.equal("service1-username1");
+		expect(IBMCloudEnv.getDictionary("cf_var4")).to.be.an("object");
+		expect(IBMCloudEnv.getDictionary("cf_var4")).to.have.a.property("value");
+		expect(IBMCloudEnv.getDictionary("cf_var4").value).to.equal("service1-username1");
 	});
 
 	it('Should be able to get simple string from environment var', function () {


### PR DESCRIPTION
This test will not pass without some work in the production code.

I used this site:  http://jsonpath.com/

Entered this "JSON" (which is directly from `test/cases/fake-env-vars.js`):

```
{
	"service1": [
		{
			"name": "service1-name1",
			"credentials": {
				"username": "service1-username1"
			}
		},
		{
			"name": "service1-name2",
			"credentials": {
				"username": "service1-username2"
			}
		}
	],
	"user-provided": [
		{
			"name": "service2-name1",
			"credentials":{
				"username": "service2-username1"
			}
		}
	]
}
```

This JSONPath Syntax:

```
$.[?(@.name == 'service1-name1')].credentials.username
```

And got expected results:

```
[
  "service1-username1"
]
```

I set up a unit test to drive this required feature, and `npm run test` fails with the PR I've submitted.