### PR TITLE
fix: save hub source code in /tmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ node_js:
 before_install:
 - npm i -g makeshift && makeshift -r https://registry.npmjs.org
 - npm i -g markdown-to-html
-- wget https://github.com/github/hub/releases/download/v2.2.9/hub-linux-386-2.2.9.tgz
-- tar -xvzf hub-linux-386-2.2.9.tgz
-- export PATH=${PATH}:$PWD/hub-linux-386-2.2.9/bin/
+- wget -O /tmp/hub-linux-386-2.2.9.tgz https://github.com/github/hub/releases/download/v2.2.9/hub-linux-386-2.2.9.tgz
+- mkdir -p /tmp/hub
+- tar -xvzf /tmp/hub-linux-386-2.2.9.tgz -C /tmp/hub
+- export PATH=${PATH}:/tmp/hub/bin/
 script: npm test && npm run coveralls && ./npm_version_upgrade.sh
 branches:
   only:


### PR DESCRIPTION
* downloading and building source code in tmp directory will prevent hub source from being publish with generator