### PR TITLE
docs(logging): clarified logging for no search pattern found for mapping name

### DIFF
--- a/lib/lib.js
+++ b/lib/lib.js
@@ -58,7 +58,7 @@ function IBMCloudEnv() {
 		logger.trace("processMapping", mappingName, config);
 
 		if (!config.searchPatterns || config.searchPatterns.length === 0) {
-			logger.warn("No searchPatterns found for mapping", mappingName);
+			logger.warn(`No credentials found using searchPatterns under ${mappingName} skipping...`);
 			return;
 		}
 		config.searchPatterns.every(function (searchPattern) {
@@ -84,7 +84,7 @@ function IBMCloudEnv() {
 			let key = keys[i];
 
 			if (!config[key].searchPatterns || config[key].searchPatterns.length === 0) {
-				logger.warn(`No searchPatterns found for mapping ${mappingName}[${key}]`);
+				logger.warn(`No credentials found using searchPatterns under ${mappingName} skipping...`);
 				return;
 			}
 


### PR DESCRIPTION
Warning message should be clear that the credentials cannot be found using the searchPatterns specified in a mapping name.

For instance

```
{ 
  "service-name": 
     "searchPatterns": {
       "env: "IDONTEXISTLEAVEMEALONE"
    }
}
```